### PR TITLE
Radio bugfix & returned value attribute value for checkable inputs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ module.exports = function (form) {
       case 'submit':
       case 'button':
         return
-      case 'checkbox': return body[el.name] = !!el.checked
+      case 'checkbox': 
       case 'radio':
-        if (el.selected) body[el.name] = el.value
+        if (el.checked) body[el.name] = el.value
         return
     }
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 
 /* jshint -W093 */
 
-var closest = require('component-closest')
-
 var slice = [].slice
 
 module.exports = function (form) {
@@ -14,9 +12,8 @@ module.exports = function (form) {
     if (!el.name) return
     // if an element is read only, then it doesn't make sense to send client
     if (el.readOnly) return
-    // if the element is disabled or any ancestor is disabled,
-    // then it shouldn't be sent to the server
-    if (closest(el, '[disabled]', true)) return
+    // if the element is disabled then it wouldn't be sent to the server
+    if (el.disabled) return
 
     switch (el.tagName.toLowerCase()) {
       case 'textarea': return body[el.name] = el.value

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
   "repository": "jonathanong/form-to-object",
-  "dependencies": {
-    "component-closest": "^0.1.4"
-  },
   "devDependencies": {
     "mocha": "2",
     "istanbul": "0"


### PR DESCRIPTION
`selected` isn't an attribute of radio elements, they use `checked` just like checkboxes. Checkboxes and radios have a value attribute, so that attribute value should be returned instead of the checked state.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input

> A radio button. You must use the value attribute to define the value submitted by this item. Use the checked attribute to indicate whether this item is selected by default.
